### PR TITLE
Add the login package

### DIFF
--- a/login/callback.go
+++ b/login/callback.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type callbackBackend interface {
+	Token(r *ims.TokenRequest) (*ims.TokenResponse, error)
+}
+
+type callbackMiddleware struct {
+	client       callbackBackend
+	state        string
+	clientID     string
+	clientSecret string
+	scope        []string
+	next         http.Handler
+}
+
+func (h *callbackMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	values := r.URL.Query()
+
+	uerr := values.Get("error")
+	if uerr != "" {
+		serveError(h.next, w, r, fmt.Errorf("backend error: %s", uerr))
+		return
+	}
+
+	state := values.Get("state")
+	if state == "" {
+		serveError(h.next, w, r, fmt.Errorf("missing state parameter"))
+		return
+	}
+
+	if h.state != state {
+		serveError(h.next, w, r, fmt.Errorf("invalid state parameter"))
+		return
+	}
+
+	code := values.Get("code")
+	if code == "" {
+		serveError(h.next, w, r, fmt.Errorf("missing code parameter"))
+		return
+	}
+
+	res, err := h.client.Token(&ims.TokenRequest{
+		Code:         code,
+		ClientID:     h.clientID,
+		ClientSecret: h.clientSecret,
+		Scope:        h.scope,
+	})
+	if err != nil {
+		serveError(h.next, w, r, fmt.Errorf("obtaining access token: %v", err))
+		return
+	}
+
+	serveResult(h.next, w, r, res)
+}

--- a/login/callback_test.go
+++ b/login/callback_test.go
@@ -1,0 +1,202 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type testCallbackBackend func(r *ims.TokenRequest) (*ims.TokenResponse, error)
+
+func (b testCallbackBackend) Token(r *ims.TokenRequest) (*ims.TokenResponse, error) {
+	return b(r)
+}
+
+func urlWithParams(path string, params map[string]string) string {
+	values := url.Values{}
+
+	for k, v := range params {
+		values.Set(k, v)
+	}
+
+	u := url.URL{
+		Path:     path,
+		RawQuery: values.Encode(),
+	}
+
+	return u.String()
+}
+
+func TestCallback(t *testing.T) {
+	m := &callbackMiddleware{
+		state:        "state",
+		clientID:     "client-id",
+		clientSecret: "client-secret",
+		scope:        []string{"a", "b"},
+
+		client: testCallbackBackend(func(r *ims.TokenRequest) (*ims.TokenResponse, error) {
+			if r.Code != "code" {
+				t.Fatalf("invalid code: %v", r.Code)
+			}
+			if r.ClientID != "client-id" {
+				t.Fatalf("invalid client ID: %v", r.ClientID)
+			}
+			if r.ClientSecret != "client-secret" {
+				t.Fatalf("invalid client secret: %v", r.ClientSecret)
+			}
+			if len(r.Scope) != 2 && r.Scope[0] != "a" && r.Scope[1] != "b" {
+				t.Fatalf("invalid scope: %v", r.Scope)
+			}
+			return &ims.TokenResponse{}, nil
+		}),
+
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			res, ok := r.Context().Value(contextKeyResult).(*ims.TokenResponse)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if res == nil {
+				t.Fatalf("no response returned")
+			}
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"code":  "code",
+		"state": "state",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+}
+
+func TestCallbackError(t *testing.T) {
+	m := &callbackMiddleware{
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("no error returned")
+			}
+			if err.Error() != "backend error: error" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"error": "error",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+}
+
+func TestCallbackNoState(t *testing.T) {
+	m := &callbackMiddleware{
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("no error returned")
+			}
+			if err.Error() != "missing state parameter" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, "/", nil))
+}
+
+func TestCallbackInvalidState(t *testing.T) {
+	m := &callbackMiddleware{
+		state: "state",
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("no error returned")
+			}
+			if err.Error() != "invalid state parameter" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"state": "invalid-state",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+}
+
+func TestCallbackMissingCode(t *testing.T) {
+	m := &callbackMiddleware{
+		state: "state",
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("no error returned")
+			}
+			if err.Error() != "missing code parameter" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"state": "state",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+}
+
+func TestCallbackBackendError(t *testing.T) {
+	m := &callbackMiddleware{
+		state: "state",
+		client: testCallbackBackend(func(r *ims.TokenRequest) (*ims.TokenResponse, error) {
+			return nil, fmt.Errorf("error")
+		}),
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("no error returned")
+			}
+			if err.Error() != "obtaining access token: error" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"state": "state",
+		"code":  "code",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+}

--- a/login/context.go
+++ b/login/context.go
@@ -1,0 +1,37 @@
+// ADOBE CONFIDENTIAL
+// ___________________
+//
+//  Copyright 2019 Adobe Systems Incorporated
+//  All Rights Reserved.
+//
+// NOTICE:  All information contained herein is, and remains the property of
+// Adobe Systems Incorporated and its suppliers, if any.  The intellectual and
+// technical concepts contained herein are proprietary to Adobe Systems
+// Incorporated and its suppliers and are protected by trade secret or copyright
+// law. Dissemination of this information or reproduction of this material is
+// strictly forbidden unless prior written permission is obtained from Adobe
+// Systems Incorporated.
+
+package login
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type contextKey string
+
+var (
+	contextKeyError  = contextKey("error")
+	contextKeyResult = contextKey("result")
+)
+
+func serveError(h http.Handler, w http.ResponseWriter, r *http.Request, err error) {
+	h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), contextKeyError, err)))
+}
+
+func serveResult(h http.Handler, w http.ResponseWriter, r *http.Request, res *ims.TokenResponse) {
+	h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), contextKeyResult, res)))
+}

--- a/login/redirect.go
+++ b/login/redirect.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type redirectBackend interface {
+	AuthorizeURL(cfg *ims.AuthorizeURLConfig) (string, error)
+}
+
+type redirectMiddleware struct {
+	client   redirectBackend
+	clientID string
+	scope    []string
+	state    string
+	next     http.Handler
+}
+
+func (h *redirectMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url, err := h.client.AuthorizeURL(&ims.AuthorizeURLConfig{
+		ClientID: h.clientID,
+		Scope:    h.scope,
+		State:    h.state,
+	})
+	if err != nil {
+		serveError(h.next, w, r, fmt.Errorf("generate authorization URL: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, url, http.StatusFound)
+}

--- a/login/redirect_test.go
+++ b/login/redirect_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type testRedirectBackend func(cfg *ims.AuthorizeURLConfig) (string, error)
+
+func (b testRedirectBackend) AuthorizeURL(cfg *ims.AuthorizeURLConfig) (string, error) {
+	return b(cfg)
+}
+
+func TestRedirect(t *testing.T) {
+	m := &redirectMiddleware{
+		clientID: "client-id",
+		scope:    []string{"a", "b"},
+		state:    "state",
+		client: testRedirectBackend(func(cfg *ims.AuthorizeURLConfig) (string, error) {
+			if cfg.ClientID != "client-id" {
+				t.Fatalf("invalid client ID: %v", cfg.ClientID)
+			}
+			if cfg.State != "state" {
+				t.Fatalf("invalid state: %v", cfg.State)
+			}
+			if len(cfg.Scope) != 2 && cfg.Scope[0] != "a" && cfg.Scope[1] != "b" {
+				t.Fatalf("invalid scope: %v", cfg.Scope)
+			}
+			return "http://acme.com/login", nil
+		}),
+	}
+
+	w := httptest.NewRecorder()
+
+	m.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	r := w.Result()
+
+	if r.StatusCode != http.StatusFound {
+		t.Fatalf("invalid status code: %v", r.StatusCode)
+	}
+	if h := r.Header.Get("location"); h != "http://acme.com/login" {
+		t.Fatalf("invalid location: %v", h)
+	}
+}
+
+func TestRedirectBackendError(t *testing.T) {
+	m := &redirectMiddleware{
+		clientID: "client-id",
+		scope:    []string{"a", "b"},
+		state:    "state",
+		client: testRedirectBackend(func(cfg *ims.AuthorizeURLConfig) (string, error) {
+			return "", fmt.Errorf("error")
+		}),
+		next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err, ok := r.Context().Value(contextKeyError).(error)
+			if !ok {
+				t.Fatalf("invalid context value")
+			}
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if err.Error() != "generate authorization URL: error" {
+				t.Fatalf("invalid error: %v", err)
+			}
+		}),
+	}
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, "/", nil))
+}

--- a/login/result.go
+++ b/login/result.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+type resultHandler struct {
+	successHandler http.Handler
+	failureHandler http.Handler
+	resCh          chan<- *ims.TokenResponse
+	errCh          chan<- error
+}
+
+func (h *resultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if result, ok := r.Context().Value(contextKeyResult).(*ims.TokenResponse); ok {
+		if h.successHandler != nil {
+			h.successHandler.ServeHTTP(w, r)
+		} else {
+			fmt.Fprintf(w, "Success!")
+		}
+
+		select {
+		case h.resCh <- result:
+			// Result sent.
+		case <-r.Context().Done():
+			// Request cancelled.
+		}
+
+		return
+	}
+
+	var serr error
+
+	if err, ok := r.Context().Value(contextKeyError).(error); ok {
+		serr = err
+	} else {
+		serr = fmt.Errorf("neither error nor result returned")
+	}
+
+	if h.failureHandler != nil {
+		h.failureHandler.ServeHTTP(w, r)
+	} else {
+		fmt.Fprintf(w, "Error: %v", serr)
+	}
+
+	select {
+	case h.errCh <- serr:
+		// Error sent.
+	case <-r.Context().Done():
+		// Request cancelled.
+	}
+}

--- a/login/result_test.go
+++ b/login/result_test.go
@@ -1,0 +1,137 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+func TestResult(t *testing.T) {
+	resCh := make(chan *ims.TokenResponse)
+
+	h := &resultHandler{
+		resCh: resCh,
+	}
+
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), contextKeyResult, &ims.TokenResponse{}))
+
+	go h.ServeHTTP(w, r)
+
+	if res := <-resCh; res == nil {
+		t.Fatalf("expected a response")
+	}
+
+	if s := string(w.Body.Bytes()); s != "Success!" {
+		t.Fatalf("invalid body: %v", s)
+	}
+}
+
+func TestResultError(t *testing.T) {
+	errCh := make(chan error)
+
+	h := &resultHandler{
+		errCh: errCh,
+	}
+
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), contextKeyError, fmt.Errorf("error")))
+
+	go h.ServeHTTP(w, r)
+
+	if err := <-errCh; err == nil {
+		t.Fatalf("error expected")
+	} else if err.Error() != "error" {
+		t.Fatalf("invalid error: %v", err)
+	}
+
+	if s := string(w.Body.Bytes()); s != "Error: error" {
+		t.Fatalf("invalid body: %v", s)
+	}
+}
+
+func TestResultSuccessHandler(t *testing.T) {
+	resCh := make(chan *ims.TokenResponse)
+
+	h := &resultHandler{
+		resCh: resCh,
+		successHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "custom")
+		}),
+	}
+
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), contextKeyResult, &ims.TokenResponse{}))
+
+	go h.ServeHTTP(w, r)
+
+	<-resCh
+
+	if s := string(w.Body.Bytes()); s != "custom" {
+		t.Fatalf("invalid body: %v", s)
+	}
+}
+
+func TestResultFailureHandler(t *testing.T) {
+	errCh := make(chan error)
+
+	h := &resultHandler{
+		errCh: errCh,
+		failureHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "custom")
+		}),
+	}
+
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), contextKeyError, fmt.Errorf("error")))
+
+	go h.ServeHTTP(w, r)
+
+	<-errCh
+
+	if s := string(w.Body.Bytes()); s != "custom" {
+		t.Fatalf("invalid body: %v", s)
+	}
+}
+
+func TestResultInvalidContext(t *testing.T) {
+	errCh := make(chan error)
+
+	h := &resultHandler{
+		errCh: errCh,
+	}
+
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	go h.ServeHTTP(w, r)
+
+	if err := <-errCh; err == nil {
+		t.Fatalf("error expected")
+	} else if err.Error() != "neither error nor result returned" {
+		t.Fatalf("invalid error: %v", err)
+	}
+}

--- a/login/route.go
+++ b/login/route.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"net/http"
+)
+
+type routeMiddleware struct {
+	redirect http.Handler
+	callback http.Handler
+}
+
+func (h *routeMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	if q.Get("code") != "" || q.Get("error") != "" {
+		h.callback.ServeHTTP(w, r)
+		return
+	}
+
+	h.redirect.ServeHTTP(w, r)
+}

--- a/login/route_test.go
+++ b/login/route_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoute(t *testing.T) {
+	var redirect bool
+
+	m := &routeMiddleware{
+		redirect: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			redirect = true
+		}),
+	}
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !redirect {
+		t.Fatalf("redirect handler not invoked")
+	}
+}
+
+func TestRouteWithCode(t *testing.T) {
+	var callback bool
+
+	m := &routeMiddleware{
+		callback: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callback = true
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"code": "code",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+
+	if !callback {
+		t.Fatalf("callback handler not invoked")
+	}
+}
+
+func TestRouteWithError(t *testing.T) {
+	var callback bool
+
+	m := &routeMiddleware{
+		callback: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callback = true
+		}),
+	}
+
+	target := urlWithParams("/", map[string]string{
+		"error": "error",
+	})
+
+	m.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, target, nil))
+
+	if !callback {
+		t.Fatalf("callback handler not invoked")
+	}
+}

--- a/login/server.go
+++ b/login/server.go
@@ -1,0 +1,153 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+// Server is the local server used to perform a user login in IMS.
+//
+// The usage pattern for the login server (minus error handling, for simplicity)
+// is the following.
+//
+//  // Start the service
+//  srv := login.NewServer(cfg)
+//
+//  // Listen on a spearate goroutine
+//  go srv.Serve(listener)
+//
+//  // Wait for a response.
+//  select {
+//  case res := <-srv.Response():
+//      // Process the login response.
+//  case err := <-srv.Error():
+//      // An error occurred.
+//  case <- time.After(5 * time.Minute):
+//      // Bail out after some time.
+//  }
+//
+//  // Close the server.
+//  srv.Shutdown()
+type Server struct {
+	server *http.Server
+	resCh  chan *ims.TokenResponse
+	errCh  chan error
+}
+
+// ServerConfig is the configuration for the login server.
+type ServerConfig struct {
+	// The IMS client.
+	Client *ims.Client
+	// The client ID.
+	ClientID string
+	// The client secret.
+	ClientSecret string
+	// The scope.
+	Scope []string
+	// A custom handler for sending an error response to the client. If not
+	// provided, a default response is sent.
+	OnError http.Handler
+	// A custom handler for sending a success response to the client. If not
+	// provided, a default response is sent.
+	OnSuccess http.Handler
+}
+
+// NewServer creates a new Server for the provided ServerConfig.
+func NewServer(cfg *ServerConfig) (*Server, error) {
+	state, err := randomState()
+	if err != nil {
+		return nil, fmt.Errorf("generate random state: %v", err)
+	}
+
+	var (
+		resCh = make(chan *ims.TokenResponse)
+		errCh = make(chan error)
+	)
+
+	result := &resultHandler{
+		successHandler: cfg.OnSuccess,
+		failureHandler: cfg.OnError,
+		resCh:          resCh,
+		errCh:          errCh,
+	}
+
+	route := &routeMiddleware{
+		redirect: &redirectMiddleware{
+			client:   cfg.Client,
+			clientID: cfg.ClientID,
+			scope:    cfg.Scope,
+			state:    state,
+			next:     result,
+		},
+
+		callback: &callbackMiddleware{
+			client:       cfg.Client,
+			clientID:     cfg.ClientID,
+			clientSecret: cfg.ClientSecret,
+			scope:        cfg.Scope,
+			state:        state,
+			next:         result,
+		},
+	}
+
+	server := &http.Server{
+		Handler: route,
+	}
+
+	return &Server{
+		server: server,
+		resCh:  resCh,
+		errCh:  errCh,
+	}, nil
+}
+
+// Serve make the server listen to the provided listener.
+func (s *Server) Serve(lst net.Listener) error {
+	return s.server.Serve(lst)
+}
+
+// Shutdown closes the server and the channels returned from Error() and
+// Response(). When closing the server, this method has the same semantycs of
+// http.Server.Shutdown.
+func (s *Server) Shutdown(ctx context.Context) error {
+	defer close(s.errCh)
+	defer close(s.resCh)
+
+	return s.server.Shutdown(ctx)
+}
+
+// Error returns a channel that can be listened to for error conditions.
+func (s *Server) Error() <-chan error {
+	return s.errCh
+}
+
+// Response returns a channel that can be listened to for a successful login.
+func (s *Server) Response() <-chan *ims.TokenResponse {
+	return s.resCh
+}
+
+func randomState() (string, error) {
+	binaryData := make([]byte, 128)
+
+	if _, err := rand.Read(binaryData); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(binaryData), nil
+}

--- a/login/server_test.go
+++ b/login/server_test.go
@@ -1,0 +1,184 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package login_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/adobe/ims-go/ims"
+	"github.com/adobe/ims-go/login"
+)
+
+func TestServerLogin(t *testing.T) {
+	lst, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// Login backend setup
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ims/authorize/v1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := url.Values{}
+		v.Add("code", "code")
+		v.Add("state", r.URL.Query().Get("state"))
+
+		u := url.URL{
+			Host:     fmt.Sprintf("localhost:%d", port(lst)),
+			RawQuery: v.Encode(),
+		}
+
+		http.Redirect(w, r, u.String(), http.StatusFound)
+	}))
+
+	mux.Handle("/ims/token/v2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+			"access_token": "access-token",
+			"refresh_token": "refresh-token",
+			"expires_in": 3600
+		}`)
+	}))
+
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	// Login server setup
+
+	client, err := ims.NewClient(&ims.ClientConfig{
+		URL: backend.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	server, err := login.NewServer(&login.ServerConfig{
+		Client:       client,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scope:        []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	go server.Serve(lst)
+
+	// User flow
+
+	go func() {
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d/", port(lst)))
+		if err != nil {
+			t.Fatalf("perform initial request: %v", err)
+		}
+		defer res.Body.Close()
+	}()
+
+	select {
+	case res := <-server.Response():
+		if res.AccessToken != "access-token" {
+			t.Fatalf("invalid access token: %v", res.AccessToken)
+		}
+		if res.RefreshToken != "refresh-token" {
+			t.Fatalf("invalid refresh token: %v", res.RefreshToken)
+		}
+		if res.ExpiresIn != 3600*time.Second {
+			t.Fatalf("invalid expiration time: %v", res.ExpiresIn)
+		}
+	case err := <-server.Error():
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := server.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func TestServerError(t *testing.T) {
+	lst, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// Login backend setup
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ims/authorize/v1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := url.Values{}
+		v.Add("error", "error")
+
+		u := url.URL{
+			Host:     fmt.Sprintf("localhost:%d", port(lst)),
+			RawQuery: v.Encode(),
+		}
+
+		http.Redirect(w, r, u.String(), http.StatusFound)
+	}))
+
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	// Login server setup
+
+	client, err := ims.NewClient(&ims.ClientConfig{
+		URL: backend.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	server, err := login.NewServer(&login.ServerConfig{
+		Client:       client,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scope:        []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	go server.Serve(lst)
+
+	// User flow
+
+	go func() {
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d/", port(lst)))
+		if err != nil {
+			t.Fatalf("perform initial request: %v", err)
+		}
+		defer res.Body.Close()
+	}()
+
+	select {
+	case <-server.Response():
+		t.Fatalf("error expected")
+	case err := <-server.Error():
+		if err.Error() != "backend error: error" {
+			t.Fatalf("invalid error: %v", err)
+		}
+	}
+
+	if err := server.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func port(lst net.Listener) int {
+	return lst.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
This PR adds a package with a generic login server that can be used in conjunction with the IMS client to perform the user login flow.