### PR TITLE
Added raw ims response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ Temporary Items
 .apdisk
 
 # End of https://www.gitignore.io/api/go,osx
+
+.idea

--- a/ims/token.go
+++ b/ims/token.go
@@ -41,8 +41,8 @@ type TokenResponse struct {
 	RefreshToken string
 	// ExpiresIn is the expiration time of the access token.
 	ExpiresIn time.Duration
-	// Raw ims response
-	IMSRawResponse map[string]interface{}
+	// User id received from IMS token
+	UserId string
 }
 
 // Token requests an access token.
@@ -80,16 +80,21 @@ func (c *Client) Token(r *TokenRequest) (*TokenResponse, error) {
 		return nil, errorResponse(res)
 	}
 
-	tokenMapResponse := make(map[string]interface{})
+	var payload struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		UserId       string `json:"userId"`
+	}
 
-	if err := json.NewDecoder(res.Body).Decode(&tokenMapResponse); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
 		return nil, fmt.Errorf("decode response: %v", err)
 	}
 
 	return &TokenResponse{
-		AccessToken:    tokenMapResponse["access_token"].(string),
-		RefreshToken:   tokenMapResponse["refresh_token"].(string),
-		ExpiresIn:      time.Second * time.Duration(tokenMapResponse["expires_in"].(float64)),
-		IMSRawResponse: tokenMapResponse,
+		AccessToken:  payload.AccessToken,
+		RefreshToken: payload.RefreshToken,
+		ExpiresIn:    time.Second * time.Duration(payload.ExpiresIn),
+		UserId:       payload.UserId,
 	}, nil
 }

--- a/ims/token.go
+++ b/ims/token.go
@@ -41,6 +41,8 @@ type TokenResponse struct {
 	RefreshToken string
 	// ExpiresIn is the expiration time of the access token.
 	ExpiresIn time.Duration
+	// Raw ims response
+	IMSRawResponse map[string]interface{}
 }
 
 // Token requests an access token.
@@ -78,19 +80,16 @@ func (c *Client) Token(r *TokenRequest) (*TokenResponse, error) {
 		return nil, errorResponse(res)
 	}
 
-	var payload struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		ExpiresIn    int    `json:"expires_in"`
-	}
+	tokenMapResponse := make(map[string]interface{})
 
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&tokenMapResponse); err != nil {
 		return nil, fmt.Errorf("decode response: %v", err)
 	}
 
 	return &TokenResponse{
-		AccessToken:  payload.AccessToken,
-		RefreshToken: payload.RefreshToken,
-		ExpiresIn:    time.Second * time.Duration(payload.ExpiresIn),
+		AccessToken:    tokenMapResponse["access_token"].(string),
+		RefreshToken:   tokenMapResponse["refresh_token"].(string),
+		ExpiresIn:      time.Second * time.Duration(tokenMapResponse["expires_in"].(float64)),
+		IMSRawResponse: tokenMapResponse,
 	}, nil
 }

--- a/ims/token_test.go
+++ b/ims/token_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
@@ -22,6 +21,8 @@ import (
 )
 
 func TestToken(t *testing.T) {
+	expectedUserId := "someRondomString"
+
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("invalid method: %v", r.Method)
@@ -52,10 +53,12 @@ func TestToken(t *testing.T) {
 			ExpiresIn    int    `json:"expires_in"`
 			RefreshToken string `json:"refresh_token"`
 			AccessToken  string `json:"access_token"`
+			UserId       string `json:"userId"`
 		}{
 			ExpiresIn:    3600,
 			RefreshToken: "refreshToken",
 			AccessToken:  "accessToken",
+			UserId:       expectedUserId,
 		}
 
 		if err := json.NewEncoder(w).Encode(&body); err != nil {
@@ -89,13 +92,8 @@ func TestToken(t *testing.T) {
 	if r.ExpiresIn != 3600*time.Second {
 		t.Errorf("invalid expiration: %v", r.ExpiresIn)
 	}
-	expectedMap := map[string]interface{}{
-		"access_token": r.AccessToken,
-		"refresh_token": r.RefreshToken,
-		"expires_in": float64(3600),
-	}
-	if reflect.DeepEqual(r.IMSRawResponse, expectedMap) != true {
-		t.Errorf("invalid IMSRawResponse: %v expected %v", r.IMSRawResponse, expectedMap)
+	if r.UserId != expectedUserId {
+		t.Errorf("invalid userId: %v expected %v", r.UserId, expectedUserId)
 	}
 }
 

--- a/ims/token_test.go
+++ b/ims/token_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -87,6 +88,14 @@ func TestToken(t *testing.T) {
 	}
 	if r.ExpiresIn != 3600*time.Second {
 		t.Errorf("invalid expiration: %v", r.ExpiresIn)
+	}
+	expectedMap := map[string]interface{}{
+		"access_token": r.AccessToken,
+		"refresh_token": r.RefreshToken,
+		"expires_in": float64(3600),
+	}
+	if reflect.DeepEqual(r.IMSRawResponse, expectedMap) != true {
+		t.Errorf("invalid IMSRawResponse: %v expected %v", r.IMSRawResponse, expectedMap)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Octavian Ionescu <itavyg@gmail.com>


## Description

I added an extra field IMSRawResponse to structure returned by ims login. it is helpful to have access to different token claims apart the one you already provided.
i chose to implemented it as map for feature compatibility 

as first use case i need to have access to userId field inside cmcli

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.