### PR TITLE
Add meta-scope for Analytics Bulk Ingest

### DIFF
--- a/ims/exchange_jwt.go
+++ b/ims/exchange_jwt.go
@@ -27,6 +27,8 @@ const (
 	MetaScopeCloudManager MetaScope = iota
 	// MetaScopeAdobeIO is the meta-scope for Adobe IO
 	MetaScopeAdobeIO
+	// MetaScopeAnalyticsBulkIngest is the meta-scope for Analytics Bulk Ingest
+	MetaScopeAnalyticsBulkIngest
 )
 
 // ExchangeJWTRequest contains the data for exchanging a JWT token with an
@@ -77,6 +79,8 @@ func (c *Client) ExchangeJWT(r *ExchangeJWTRequest) (*ExchangeJWTResponse, error
 			claims[fmt.Sprintf("%v/s/ent_cloudmgr_sdk", c.url)] = true
 		case MetaScopeAdobeIO:
 			claims[fmt.Sprintf("%v/s/ent_adobeio_sdk", c.url)] = true
+		case MetaScopeAnalyticsBulkIngest:
+			claims[fmt.Sprintf("%v/s/ent_analytics_bulk_ingest_sdk", c.url)] = true
 		default:
 			return nil, fmt.Errorf("invalid meta-scope: %v", ms)
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the meta scope  `ent_analytics_bulk_ingest_sdk` for Analytics Bulk Ingest

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #4 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To be able to get an Analytics 2.0 API Report the meta scope `ent_analytics_bulk_ingest_sdk` seems to be required. Using the available Adobe I/O metascope results in the error 
```
The JWT token must contain a valid claims for audience
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested by using `github.com/roele/ims-go/ims@8504ca3`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.