### PR TITLE
Profile request + tiny bug correction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-module github.com/adobe/ims-go
+module github.com/telegrapher/ims-go
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-module github.com/telegrapher/ims-go
+module github.com/adobe/ims-go
 
 go 1.13
 

--- a/ims/error.go
+++ b/ims/error.go
@@ -13,6 +13,7 @@ package ims
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -48,8 +49,14 @@ func errorResponse(r *http.Response) error {
 		ErrorMessage string `json:"error_description"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		return fmt.Errorf("decode error response: %v", err)
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("error reading request body")
+	}
+	if len(body) != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			return fmt.Errorf("decode error response: %v", err)
+		}
 	}
 
 	return &Error{

--- a/ims/error.go
+++ b/ims/error.go
@@ -51,12 +51,13 @@ func errorResponse(r *http.Response) error {
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return fmt.Errorf("error reading request body")
+		return fmt.Errorf("error reading request body: %v", err)
 	}
 	if len(body) != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		if err := json.Unmarshal(body,&payload); err != nil {
 			return fmt.Errorf("decode error response: %v", err)
 		}
+
 	}
 
 	return &Error{

--- a/ims/profile.go
+++ b/ims/profile.go
@@ -16,31 +16,42 @@ import (
 	"net/http"
 )
 
-// The user token is used to authorize the request and to define which user's profile is requested.
-func (c *Client) GetProfile(userToken string) (string, error){
+type GetProfileRequest struct {
+	AccessToken string
+}
 
-	// Create request
+type GetProfileResponse struct {
+	Body []byte
+}
+
+// The user token is used to authorize the request and to define which user's profile is requested.
+func (c *Client) GetProfile(r *GetProfileRequest) (*GetProfileResponse, error){
+
+	// Empty profile response
+	pr := &GetProfileResponse{}
+
+	// Create HTTP request
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/ims/profile/v1", c.url), nil)
 
 	// Add the user token as Bearer token
-	bearer := fmt.Sprintf("Bearer %v", userToken)
+	bearer := fmt.Sprintf("Bearer %v", r.AccessToken)
 	req.Header.Add("Authorization", bearer )
 
 	// Perform request
 	res, err := c.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("error requesting profile: %v", err)
+		return pr, fmt.Errorf("error requesting profile: %v", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return "", errorResponse(res)
+		return pr, errorResponse(res)
 	}
 
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading request body")
+		return pr, fmt.Errorf("error reading request body")
 	}
 
-	return string(bodyBytes), nil
+	return &GetProfileResponse{bodyBytes}, nil
 }

--- a/ims/profile.go
+++ b/ims/profile.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// The user token is used to authorize the request and to define which user's profile is requested.
+type UserToken struct {
+	string
+}
+
+type UserProfile struct{
+	string
+}
+
+func (c *Client) GetProfile(t *UserToken) (*UserProfile, error){
+
+	up := &UserProfile{}
+	// Create request
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/ims/profile/v1", c.url), nil)
+
+	// Add the user token as Bearer token
+	bearer := fmt.Sprintf("Bearer %v", *t)
+	req.Header.Add("Authorization", bearer )
+
+	// Perform request
+	res, err := c.client.Do(req)
+	if err != nil {
+		return up, fmt.Errorf("error requesting profile: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return up, errorResponse(res)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return up, fmt.Errorf("error reading request body")
+	}
+	up = &UserProfile{string(bodyBytes)}
+
+	return up, nil
+}

--- a/ims/profile.go
+++ b/ims/profile.go
@@ -17,40 +17,30 @@ import (
 )
 
 // The user token is used to authorize the request and to define which user's profile is requested.
-type UserToken struct {
-	string
-}
+func (c *Client) GetProfile(userToken string) (string, error){
 
-type UserProfile struct{
-	string
-}
-
-func (c *Client) GetProfile(t *UserToken) (*UserProfile, error){
-
-	up := &UserProfile{}
 	// Create request
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/ims/profile/v1", c.url), nil)
 
 	// Add the user token as Bearer token
-	bearer := fmt.Sprintf("Bearer %v", *t)
+	bearer := fmt.Sprintf("Bearer %v", userToken)
 	req.Header.Add("Authorization", bearer )
 
 	// Perform request
 	res, err := c.client.Do(req)
 	if err != nil {
-		return up, fmt.Errorf("error requesting profile: %v", err)
+		return "", fmt.Errorf("error requesting profile: %v", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return up, errorResponse(res)
+		return "", errorResponse(res)
 	}
 
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return up, fmt.Errorf("error reading request body")
+		return "", fmt.Errorf("error reading request body")
 	}
-	up = &UserProfile{string(bodyBytes)}
 
-	return up, nil
+	return string(bodyBytes), nil
 }


### PR DESCRIPTION
## Description

Add ims/profile.go to handle profile requests to /ims/profile/v1

That endpoint returns an empty body in case of error 401, so I added a small condition to avoid decoding the empty body. With that I get at least the error code that is more valuable than the JSON decode error.

Warnings:

- I'm sending the PR for early feedback.
- My changes break 3 tests probably due to the small change in error handling, I will have a look tomorrow at that. 
- I didn't create any test for the profile.go, but it doesn't seem I can test much there, since it is extremely simple code.
- The function deals with simple strings, I avoid creating new struct types to hold only one string, but I can do that if you thing code homogeneity is more important than simplicity.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.