### PR TITLE
Get Organizations support and api versions

### DIFF
--- a/ims/client_test.go
+++ b/ims/client_test.go
@@ -1,3 +1,13 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
 package ims_test
 
 import (

--- a/ims/get_organizations.go
+++ b/ims/get_organizations.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// GetOrganizationsRequest is the request for GetOrganizations.
+type GetOrganizationsRequest struct {
+	// AccessToken is a valid access token.
+	AccessToken string
+	ApiVersion string
+}
+
+// GetOrganizationsResponse is the response for GetOrganizations.
+type GetOrganizationsResponse struct {
+	// Body is the raw response body.
+	Body []byte
+}
+
+// GetOrganizations reads the user organizations associated to a given access token. It
+// returns a non-nil response on success or an error on failure.
+func (c *Client) GetOrganizations(r *GetOrganizationsRequest) (*GetOrganizationsResponse, error) {
+	if r.ApiVersion == "" {
+		r.ApiVersion = "v5"
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/ims/organizations/%s", c.url, r.ApiVersion), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.AccessToken))
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errorResponse(res)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %v", err)
+	}
+
+	return &GetOrganizationsResponse{
+		Body: body,
+	}, nil
+}

--- a/ims/get_organizations.go
+++ b/ims/get_organizations.go
@@ -20,7 +20,7 @@ import (
 type GetOrganizationsRequest struct {
 	// AccessToken is a valid access token.
 	AccessToken string
-	ApiVersion string
+	ApiVersion  string
 }
 
 // GetOrganizationsResponse is the response for GetOrganizations.

--- a/ims/get_organizations_test.go
+++ b/ims/get_organizations_test.go
@@ -1,3 +1,13 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
 package ims_test
 
 import (

--- a/ims/get_organizations_test.go
+++ b/ims/get_organizations_test.go
@@ -1,0 +1,66 @@
+package ims_test
+
+import (
+	"fmt"
+	"github.com/adobe/ims-go/ims"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetOrganizations(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("invalid method: %v", r.Method)
+		}
+		if v := r.Header.Get("authorization"); v != "Bearer accessToken" {
+			t.Fatalf("invalid authorization header: %v", v)
+		}
+
+		fmt.Fprint(w, `{"foo":"bar"}`)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.GetProfile(&ims.GetProfileRequest{
+		AccessToken: "accessToken",
+	})
+	if err != nil {
+		t.Fatalf("get organizations: %v", err)
+	}
+
+	if body := string(res.Body); body != `{"foo":"bar"}` {
+		t.Fatalf("invalid body: %v", body)
+	}
+}
+
+func TestGetOrganizationsEmptyErrorResponse(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.GetOrganizations(&ims.GetOrganizationsRequest{})
+	if res != nil {
+		t.Fatalf("non-nil response returned")
+	}
+	if err == nil {
+		t.Fatalf("nil error returned")
+	}
+	if _, ok := ims.IsError(err); !ok {
+		t.Fatalf("invalid error type: %v", err)
+	}
+}

--- a/ims/get_profile.go
+++ b/ims/get_profile.go
@@ -20,7 +20,7 @@ import (
 type GetProfileRequest struct {
 	// AccessToken is a valid access token.
 	AccessToken string
-	ApiVersion string
+	ApiVersion  string
 }
 
 // GetProfileResponse is the response for GetProfile.

--- a/ims/get_profile.go
+++ b/ims/get_profile.go
@@ -20,6 +20,7 @@ import (
 type GetProfileRequest struct {
 	// AccessToken is a valid access token.
 	AccessToken string
+	ApiVersion string
 }
 
 // GetProfileResponse is the response for GetProfile.
@@ -31,7 +32,10 @@ type GetProfileResponse struct {
 // GetProfile reads the user profile associated to a given access token. It
 // returns a non-nil response on success or an error on failure.
 func (c *Client) GetProfile(r *GetProfileRequest) (*GetProfileResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/ims/profile/v1", c.url), nil)
+	if r.ApiVersion == "" {
+		r.ApiVersion = "v1"
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/ims/profile/%s", c.url, r.ApiVersion), nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %v", err)
 	}

--- a/ims/get_profile_test.go
+++ b/ims/get_profile_test.go
@@ -1,3 +1,13 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
 package ims_test
 
 import (


### PR DESCRIPTION

## Description

Add get organizations in an analog way to get profile.

Add api versions for both in a api compatible way.

## Motivation and Context

I need those changes to add those capabilities to imscli

## How Has This Been Tested?

Run tests and test in imscli


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.