### PR TITLE
Default http client should have timeout

### DIFF
--- a/ims/client.go
+++ b/ims/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // ClientConfig is the configuration for a Client.
@@ -36,7 +37,9 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	client := cfg.Client
 
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+		}
 	}
 
 	endpointURL, err := url.Parse(cfg.URL)


### PR DESCRIPTION
The default HTTP Client doesn't have a timeout and this may create problems (stuck cli's)

This PR changes the default HTTP Client to have a 30s timeout

