### PR TITLE
feat: Add support to validate tokens using IMS API

### DIFF
--- a/ims/client.go
+++ b/ims/client.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 )
 
 // ClientConfig is the configuration for a Client.
@@ -37,9 +36,7 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	client := cfg.Client
 
 	if client == nil {
-		client = &http.Client{
-			Timeout: 30 * time.Second,
-		}
+		client = http.DefaultClient
 	}
 
 	endpointURL, err := url.Parse(cfg.URL)

--- a/ims/client.go
+++ b/ims/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // ClientConfig is the configuration for a Client.
@@ -36,7 +37,9 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	client := cfg.Client
 
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+		}
 	}
 
 	endpointURL, err := url.Parse(cfg.URL)

--- a/ims/validate_token.go
+++ b/ims/validate_token.go
@@ -1,0 +1,79 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type TokenType string
+
+const (
+	AccessToken       TokenType = "access_token"
+	RefreshToken                = "refresh_token"
+	DeviceToken                 = "device_token"
+	AuthorizationCode           = "authorization_code"
+)
+
+// ValidateTokenRequest is the request to ValidateToken.
+type ValidateTokenRequest struct {
+	// AccessToken is a valid access token.
+	Token    string
+	Type     TokenType
+	ClientID string
+}
+
+// ValidateTokenResponse is the response to the ValidateToken request .
+type ValidateTokenResponse struct {
+	// Body is the raw response body.
+	Body []byte
+}
+
+// ValidateToken validates a token using the IMS API.
+// It returns a non-nil response on success or an error on failure.
+func (c *Client) ValidateToken(r *ValidateTokenRequest) (*ValidateTokenResponse, error) {
+
+	// The token type is a mandatory parameter and should be validated.
+	switch r.Type {
+	case AccessToken, RefreshToken, DeviceToken, AuthorizationCode:
+	default:
+		return nil, fmt.Errorf("invalid token type: %v", r.Type)
+	}
+
+	req, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("%s/ims/validate/v1?type=%s", c.url, r.Type), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %v", err)
+	}
+
+	req.Header.Set("X-IMS-ClientId", r.ClientID)
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errorResponse(res)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %v", err)
+	}
+
+	return &ValidateTokenResponse{
+		Body: body,
+	}, nil
+}

--- a/ims/validate_token.go
+++ b/ims/validate_token.go
@@ -51,12 +51,15 @@ func (c *Client) ValidateToken(r *ValidateTokenRequest) (*ValidateTokenResponse,
 	}
 
 	req, err := http.NewRequest(http.MethodGet,
-		fmt.Sprintf("%s/ims/validate/v1?type=%s", c.url, r.Type), nil)
+		fmt.Sprintf("%s/ims/validate_token/v1?type=%s&client_id=%s&token=%s",
+			c.url, r.Type, r.ClientID, r.Token), nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %v", err)
 	}
 
-	req.Header.Set("X-IMS-ClientId", r.ClientID)
+	// Setting this header is recommended in the documentation
+	// but it is not working, using client_id in the URL in the meantime
+	//req.Header.Set("X-IMS-ClientId", r.ClientID)
 
 	res, err := c.client.Do(req)
 	if err != nil {

--- a/ims/validate_token_test.go
+++ b/ims/validate_token_test.go
@@ -67,7 +67,6 @@ func TestValidateToken(t *testing.T) {
 	}
 }
 
-// Revisar esto pq no me acuerdo
 func TestValidateTokenEmptyErrorResponse(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -81,7 +80,9 @@ func TestValidateTokenEmptyErrorResponse(t *testing.T) {
 		t.Fatalf("create client: %v", err)
 	}
 
-	res, err := c.GetProfile(&ims.GetProfileRequest{})
+	res, err := c.ValidateToken(&ims.ValidateTokenRequest{
+		Type: ims.AccessToken,
+	})
 	if res != nil {
 		t.Fatalf("non-nil response returned")
 	}

--- a/ims/validate_token_test.go
+++ b/ims/validate_token_test.go
@@ -25,11 +25,10 @@ func TestValidateToken(t *testing.T) {
 			t.Fatalf("invalid method: %v", r.Method)
 		}
 
-		// X-IMS-ClientId header is mandatory
-		// This is the preferred implementation but it is not working at the moment
-		/*if h := r.Header.Get("X-IMS-ClientId"); h != "test_client_id" {
+		// Test X-IMS-ClientId header
+		if h := r.Header.Get("X-IMS-ClientId"); h != "test_client_id" {
 			t.Fatalf("invalid X-IMS-ClientId header: %v", h)
-		}*/
+		}
 
 		clientIdParam, ok := r.URL.Query()["client_id"]
 		if !ok || clientIdParam[0] == "" {

--- a/ims/validate_token_test.go
+++ b/ims/validate_token_test.go
@@ -26,14 +26,20 @@ func TestValidateToken(t *testing.T) {
 		}
 
 		// X-IMS-ClientId header is mandatory
-		if h := r.Header.Get("X-IMS-ClientId"); h != "test_client_id" {
+		// This is the preferred implementation but it is not working at the moment
+		/*if h := r.Header.Get("X-IMS-ClientId"); h != "test_client_id" {
 			t.Fatalf("invalid X-IMS-ClientId header: %v", h)
+		}*/
+
+		clientIdParam, ok := r.URL.Query()["client_id"]
+		if !ok || clientIdParam[0] == "" {
+			t.Fatalf("missing mandatory client_id URL parameter")
 		}
 
 		// Token type URL parameter is mandatory
 		typeParam, ok := r.URL.Query()["type"]
 		if !ok || typeParam[0] == "" {
-			t.Fatalf("missing type parameter in the URL")
+			t.Fatalf("missing mandatory type URL parameter")
 		}
 		var tokenType = ims.TokenType(typeParam[0])
 

--- a/ims/validate_token_test.go
+++ b/ims/validate_token_test.go
@@ -1,0 +1,94 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims_test
+
+import (
+	"fmt"
+	"github.com/adobe/ims-go/ims"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValidateToken(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only GET accepted
+		if r.Method != http.MethodGet {
+			t.Fatalf("invalid method: %v", r.Method)
+		}
+
+		// X-IMS-ClientId header is mandatory
+		if h := r.Header.Get("X-IMS-ClientId"); h != "test_client_id" {
+			t.Fatalf("invalid X-IMS-ClientId header: %v", h)
+		}
+
+		// Token type URL parameter is mandatory
+		typeParam, ok := r.URL.Query()["type"]
+		if !ok || typeParam[0] == "" {
+			t.Fatalf("missing type parameter in the URL")
+		}
+		var tokenType = ims.TokenType(typeParam[0])
+
+		switch tokenType {
+		case ims.AccessToken, ims.RefreshToken, ims.DeviceToken, ims.AuthorizationCode:
+		default:
+			t.Fatalf("incorrect type of token")
+		}
+		fmt.Fprint(w, `{"foo":"bar"}`)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.ValidateToken(&ims.ValidateTokenRequest{
+		Token:    "YOLO",
+		Type:     ims.AccessToken,
+		ClientID: "test_client_id",
+	})
+	if err != nil {
+		t.Fatalf("validate token: %v", err)
+	}
+
+	if body := string(res.Body); body != `{"foo":"bar"}` {
+		t.Fatalf("invalid body: %v", body)
+	}
+}
+
+// Revisar esto pq no me acuerdo
+func TestValidateTokenEmptyErrorResponse(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.GetProfile(&ims.GetProfileRequest{})
+	if res != nil {
+		t.Fatalf("non-nil response returned")
+	}
+	if err == nil {
+		t.Fatalf("nil error returned")
+	}
+	if _, ok := ims.IsError(err); !ok {
+		t.Fatalf("invalid error type: %v", err)
+	}
+}


### PR DESCRIPTION
IMS provides an API endpoint where tokens can be validated.

As it is usual, this has been tested by wiring the feature to imscli.