### PR TITLE
Add a common, embedded Response struct

### DIFF
--- a/ims/client.go
+++ b/ims/client.go
@@ -12,6 +12,7 @@ package ims
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -59,5 +60,32 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	return &Client{
 		url:    endpointURL.String(),
 		client: client,
+	}, nil
+}
+
+// Response contains information about the HTTP response and is embedded in
+// every other response struct.
+type Response struct {
+	// The status code of the HTTP response.
+	StatusCode int
+	// The raw body of the HTTP response.
+	Body []byte
+}
+
+func (c *Client) do(req *http.Request) (*Response, error) {
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %v", err)
+	}
+
+	return &Response{
+		StatusCode: res.StatusCode,
+		Body:       data,
 	}, nil
 }

--- a/ims/get_organizations.go
+++ b/ims/get_organizations.go
@@ -13,7 +13,6 @@ package ims
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -26,8 +25,7 @@ type GetOrganizationsRequest struct {
 
 // GetOrganizationsResponse is the response for GetOrganizations.
 type GetOrganizationsResponse struct {
-	// Body is the raw response body.
-	Body []byte
+	Response
 }
 
 // GetOrganizationsWithContext reads the user organizations associated to a
@@ -45,23 +43,17 @@ func (c *Client) GetOrganizationsWithContext(ctx context.Context, r *GetOrganiza
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.AccessToken))
 
-	res, err := c.client.Do(req)
+	res, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("perform request: %v", err)
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, errorResponse(res)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %v", err)
-	}
-
 	return &GetOrganizationsResponse{
-		Body: body,
+		Response: *res,
 	}, nil
 }
 

--- a/ims/get_profile.go
+++ b/ims/get_profile.go
@@ -13,7 +13,6 @@ package ims
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -26,8 +25,7 @@ type GetProfileRequest struct {
 
 // GetProfileResponse is the response for GetProfile.
 type GetProfileResponse struct {
-	// Body is the raw response body.
-	Body []byte
+	Response
 }
 
 // GetProfileWithContext reads the user profile associated to a given access
@@ -44,23 +42,17 @@ func (c *Client) GetProfileWithContext(ctx context.Context, r *GetProfileRequest
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.AccessToken))
 
-	res, err := c.client.Do(req)
+	res, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("perform request: %v", err)
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, errorResponse(res)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %v", err)
-	}
-
 	return &GetProfileResponse{
-		Body: body,
+		Response: *res,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds a new `Response` struct, exposing the status code and the raw body of the HTTP responses received through the library. Every "higher level" response type now embeds `Response`, allowing user of the library to inspect some data about the underlying HTTP response.