### PR TITLE
Add support for the cluster access token exchange grant type

### DIFF
--- a/ims/cluster_exchange_token.go
+++ b/ims/cluster_exchange_token.go
@@ -57,7 +57,7 @@ func (c *Client) ClusterExchangeWithContext(ctx context.Context, r *ClusterExcha
 	}
 	data.Set("scope", strings.Join(r.Scopes, ","))
 
-	req, err := http.NewRequestWithContext( ctx, http.MethodPost,
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/ims/token/v3?client_id=%s", c.url, r.ClientID),
 		strings.NewReader(data.Encode()))
 	if err != nil {

--- a/ims/cluster_exchange_token.go
+++ b/ims/cluster_exchange_token.go
@@ -26,7 +26,7 @@ import (
 type ClusterExchangeRequest struct {
 	ClientID     string
 	ClientSecret string
-	Scope        []string
+	Scopes       []string
 	UserToken    string
 	UserID       string
 	OrgID        string
@@ -55,10 +55,9 @@ func (c *Client) ClusterExchangeWithContext(ctx context.Context, r *ClusterExcha
 	default:
 		return nil, fmt.Errorf("no userID or OrgID parameters to perform the request")
 	}
+	data.Set("scope", strings.Join(r.Scopes, ","))
 
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
+	req, err := http.NewRequestWithContext( ctx, http.MethodPost,
 		fmt.Sprintf("%s/ims/token/v3?client_id=%s", c.url, r.ClientID),
 		strings.NewReader(data.Encode()))
 	if err != nil {

--- a/ims/cluster_exchange_token.go
+++ b/ims/cluster_exchange_token.go
@@ -1,0 +1,97 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// The cluster_at_exchange is an IMS specific grant type, that is used to exchange access tokens.
+// This is useful in the context of T2E compatibility. For more information see the IMS documentation.
+
+type ClusterExchangeRequest struct {
+	ClientID     string
+	ClientSecret string
+	Scope        []string
+	UserToken    string
+	UserID       string
+	OrgID        string
+}
+
+type ClusterExchangeResponse struct {
+	Response
+	AccessToken string
+	ExpiresIn   time.Duration
+}
+
+func (c *Client) ClusterExchangeWithContext(ctx context.Context, r *ClusterExchangeRequest) (*ClusterExchangeResponse, error) {
+
+	data := url.Values{}
+	data.Set("grant_type", "cluster_at_exchange")
+	data.Set("client_secret", r.ClientSecret)
+	data.Set("user_token", r.UserToken)
+	switch {
+	case r.UserID != "":
+		if r.OrgID != "" {
+			return nil, fmt.Errorf("userID and OrgID defined at the same time")
+		}
+		data.Set("user_id", r.UserID)
+	case r.OrgID != "":
+		data.Set("owning_org_id", r.OrgID)
+	default:
+		return nil, fmt.Errorf("no userID or OrgID parameters to perform the request")
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/ims/token/v3?client_id=%s", c.url, r.ClientID),
+		strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing request: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errorResponse(res)
+	}
+
+	var body struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+
+	if err := json.Unmarshal(res.Body, &body); err != nil {
+		return nil, fmt.Errorf("error decoding response: %v", err)
+	}
+
+	return &ClusterExchangeResponse{
+		Response:    *res,
+		AccessToken: body.AccessToken,
+		ExpiresIn:   time.Millisecond * time.Duration(body.ExpiresIn),
+	}, nil
+}
+
+func (c *Client) ClusterExchange(r *ClusterExchangeRequest) (*ClusterExchangeResponse, error) {
+	return c.ClusterExchangeWithContext(context.Background(), r)
+}

--- a/ims/cluster_exchange_token_test.go
+++ b/ims/cluster_exchange_token_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+func TestClusterExchange(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("invalid method: %v", r.Method)
+		}
+		if r.URL.Path != "/ims/token/v3" {
+			t.Fatalf("invalid path: %v", r.URL.Path)
+		}
+		v, ok := r.URL.Query()["client_id"]
+		if !ok || v[0] != "client-id" {
+			t.Fatalf("invalid client ID: %v", v)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if v := r.PostForm.Get("grant_type"); v != "cluster_at_exchange" {
+			t.Fatalf("incorrect grant type")
+		}
+		if v := r.PostForm.Get("user_token"); v == "" {
+			t.Fatalf("missing user token")
+		}
+		if v := r.PostForm.Get("client_id"); v != "client-id" {
+			t.Fatalf("invalid client ID: %v", v)
+		}
+		if v := r.PostForm.Get("client_secret"); v != "client-secret" {
+			t.Fatalf("invalid client secret: %v", v)
+		}
+		if v := r.PostForm.Get("owning_org_id"); v != "orgid" {
+			t.Fatalf("invalid IMS Org ID: %v", v)
+		}
+
+		body := struct {
+			TokenType   string `json:"token_type"`
+			AccessToken string `json:"access_token"`
+			ExpiresIn   int    `json:"expires_in"`
+		}{
+			TokenType:   "bearer",
+			AccessToken: "new-token",
+			ExpiresIn:   3600000,
+		}
+
+		if err := json.NewEncoder(w).Encode(&body); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	r, err := c.ClusterExchange(&ims.ClusterExchangeRequest{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scope:        []string{"yolo", "test"},
+		UserToken:    "old-token",
+		OrgID:        "orgid",
+	})
+	if err != nil {
+		t.Fatalf("failure exchanging access token: %v", err)
+	}
+	if r.AccessToken != "new-token" {
+		t.Fatalf("invalid access token: %v", r.AccessToken)
+	}
+	if r.ExpiresIn != 3600*time.Second {
+		t.Fatalf("invalid expiration: %v", r.ExpiresIn)
+	}
+}
+
+func TestClusterExchangeError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+
+		body := struct {
+			ErrorCode    string `json:"error"`
+			ErrorMessage string `json:"error_description"`
+		}{
+			ErrorCode:    "error-code",
+			ErrorMessage: "error-message",
+		}
+
+		if err := json.NewEncoder(w).Encode(&body); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = c.ClusterExchange(&ims.ClusterExchangeRequest{
+		ClientID:     "irrelevant",
+		ClientSecret: "irrelevant",
+		Scope:        []string{"yolo", "test"},
+		UserToken:    "old-token",
+		OrgID:        "orgid",
+	})
+
+	imsErr, ok := ims.IsError(err)
+	if !ok {
+		t.Fatalf("expected IMS error")
+	}
+	if imsErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid status code: %v", imsErr.StatusCode)
+	}
+	if imsErr.ErrorCode != "error-code" {
+		t.Fatalf("invalid error code: %v", imsErr.ErrorCode)
+	}
+	if imsErr.ErrorMessage != "error-message" {
+		t.Fatalf("invalid error message: %v", imsErr.ErrorMessage)
+	}
+}
+
+func TestClusterExchangeInvalidRequest(t *testing.T) {
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: "http://ims.endpoint",
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = c.ClusterExchange(&ims.ClusterExchangeRequest{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scope:        []string{"yolo", "test"},
+		UserToken:    "old-token",
+		OrgID:        "orgid",
+		UserID:       "userid",
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "userID and OrgID defined at the same time" {
+		t.Fatalf("invalid error: %v", err)
+	}
+}

--- a/ims/cluster_exchange_token_test.go
+++ b/ims/cluster_exchange_token_test.go
@@ -42,14 +42,14 @@ func TestClusterExchange(t *testing.T) {
 		if v := r.PostForm.Get("user_token"); v == "" {
 			t.Fatalf("missing user token")
 		}
-		if v := r.PostForm.Get("client_id"); v != "client-id" {
-			t.Fatalf("invalid client ID: %v", v)
-		}
 		if v := r.PostForm.Get("client_secret"); v != "client-secret" {
 			t.Fatalf("invalid client secret: %v", v)
 		}
 		if v := r.PostForm.Get("owning_org_id"); v != "orgid" {
 			t.Fatalf("invalid IMS Org ID: %v", v)
+		}
+		if v := r.PostForm.Get("scope"); v != "yolo,test" {
+			t.Fatalf("invalid scopes: %v", v)
 		}
 
 		body := struct {
@@ -78,7 +78,7 @@ func TestClusterExchange(t *testing.T) {
 	r, err := c.ClusterExchange(&ims.ClusterExchangeRequest{
 		ClientID:     "client-id",
 		ClientSecret: "client-secret",
-		Scope:        []string{"yolo", "test"},
+		Scopes:       []string{"yolo", "test"},
 		UserToken:    "old-token",
 		OrgID:        "orgid",
 	})
@@ -121,7 +121,7 @@ func TestClusterExchangeError(t *testing.T) {
 	_, err = c.ClusterExchange(&ims.ClusterExchangeRequest{
 		ClientID:     "irrelevant",
 		ClientSecret: "irrelevant",
-		Scope:        []string{"yolo", "test"},
+		Scopes:       []string{"yolo", "test"},
 		UserToken:    "old-token",
 		OrgID:        "orgid",
 	})
@@ -152,7 +152,7 @@ func TestClusterExchangeInvalidRequest(t *testing.T) {
 	_, err = c.ClusterExchange(&ims.ClusterExchangeRequest{
 		ClientID:     "client-id",
 		ClientSecret: "client-secret",
-		Scope:        []string{"yolo", "test"},
+		Scopes:       []string{"yolo", "test"},
 		UserToken:    "old-token",
 		OrgID:        "orgid",
 		UserID:       "userid",


### PR DESCRIPTION
Exchanges one access token for another from a different IMS Org (restrictions apply).

Already tested with imscli.