### PR TITLE
Run tests on all supported Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,23 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version:
+          - "1.15"
+          - "1.16"
+          - "1.17"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
-      - name: Check out code
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
         uses: actions/checkout@v2
-      - name: Run tests
-        run: go test ./... -v
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run golangci-lint
+      - name: Run linters
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
           skip-go-installation: true
+      - name: Run tests
+        run: go test ./... -v


### PR DESCRIPTION
This PR runs linters and tests on every supported Go version, starting with Go 1.15.