### PR TITLE
Add support for ims/userinfo API

### DIFF
--- a/ims/get_organizations_test.go
+++ b/ims/get_organizations_test.go
@@ -39,7 +39,7 @@ func TestGetOrganizations(t *testing.T) {
 		t.Fatalf("create client: %v", err)
 	}
 
-	res, err := c.GetProfile(&ims.GetProfileRequest{
+	res, err := c.GetOrganizations(&ims.GetOrganizationsRequest{
 		AccessToken: "accessToken",
 	})
 	if err != nil {

--- a/ims/get_userinfo.go
+++ b/ims/get_userinfo.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// GetUserInfoRequest is the request for GetUserInfo.
+type GetUserInfoRequest struct {
+	// AccessToken is a valid access token.
+	AccessToken string
+	ApiVersion  string
+}
+
+// GetUserInfoResponse is the response for GetUserInfo.
+type GetUserInfoResponse struct {
+	Response
+}
+
+// GetUserInfoWithContext reads the user profile associated to a given access
+// token. It returns a non-nil response on success or an error on failure.
+func (c *Client) GetUserInfoWithContext(ctx context.Context, r *GetUserInfoRequest) (*GetUserInfoResponse, error) {
+	if r.ApiVersion == "" {
+		r.ApiVersion = "v1"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/ims/userinfo/%s", c.url, r.ApiVersion), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.AccessToken))
+
+	res, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errorResponse(res)
+	}
+
+	return &GetUserInfoResponse{
+		Response: *res,
+	}, nil
+}
+
+// GetUserInfo is equivalent to GetUserInfoWithContext with a background context.
+func (c *Client) GetUserInfo(r *GetUserInfoRequest) (*GetUserInfoResponse, error) {
+	return c.GetUserInfoWithContext(context.Background(), r)
+}

--- a/ims/get_userinfo_test.go
+++ b/ims/get_userinfo_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+func TestGetUserInfo(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("invalid method: %v", r.Method)
+		}
+		if v := r.Header.Get("authorization"); v != "Bearer accessToken" {
+			t.Fatalf("invalid authorization header: %v", v)
+		}
+
+		fmt.Fprint(w, `{"foo":"bar"}`)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.GetUserInfo(&ims.GetUserInfoRequest{
+		AccessToken: "accessToken",
+	})
+	if err != nil {
+		t.Fatalf("get user info: %v", err)
+	}
+
+	if body := string(res.Body); body != `{"foo":"bar"}` {
+		t.Fatalf("invalid body: %v", body)
+	}
+}
+
+func TestGetUserInfoEmptyErrorResponse(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL: s.URL,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	res, err := c.GetUserInfo(&ims.GetUserInfoRequest{})
+	if res != nil {
+		t.Fatalf("non-nil response returned")
+	}
+	if err == nil {
+		t.Fatalf("nil error returned")
+	}
+	if _, ok := ims.IsError(err); !ok {
+		t.Fatalf("invalid error type: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

This pull request adds support to use the ims/userprofile API to fetch details on the current user session.

## Motivation and Context

For a Go app, we want to use the IMS /userinfo API as we only need the limited data returned here and not the full result from /profile API

## How Has This Been Tested?

Unit tests executed locally.
/userinfo function called localled with a sample Go app.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.