### PR TITLE
Support new OAUth server-to-server flow

### DIFF
--- a/ims/token.go
+++ b/ims/token.go
@@ -53,7 +53,7 @@ type TokenResponse struct {
 
 // TokenWithContext requests an access token.
 func (c *Client) TokenWithContext(ctx context.Context, r *TokenRequest) (*TokenResponse, error) {
-	if (r.Code == "") && (r.GrantType != "client_credentials") {
+	if r.Code == "" && r.GrantType != "client_credentials" {
 		return nil, fmt.Errorf("missing code")
 	}
 

--- a/ims/token.go
+++ b/ims/token.go
@@ -26,7 +26,7 @@ type TokenRequest struct {
 	// If not set, authorization_code will be used
 	GrantType string
 	// Code is the authorization code obtained via the authorization workflow.
-	// This field is required (except for GrantType=authorization_code).
+	// This field is required (except for GrantType=client_credentials).
 	Code string
 	// ClientID is the client ID. This field is required.
 	ClientID string

--- a/ims/token.go
+++ b/ims/token.go
@@ -22,8 +22,11 @@ import (
 
 // TokenRequest is the request for obtaining an access token.
 type TokenRequest struct {
+	// GrantType is the type of credentials to request.
+	// If not set, authorization_code will be used
+	GrantType string
 	// Code is the authorization code obtained via the authorization workflow.
-	// This field is required.
+	// This field is required (except for GrantType=authorization_code).
 	Code string
 	// ClientID is the client ID. This field is required.
 	ClientID string
@@ -50,7 +53,7 @@ type TokenResponse struct {
 
 // TokenWithContext requests an access token.
 func (c *Client) TokenWithContext(ctx context.Context, r *TokenRequest) (*TokenResponse, error) {
-	if r.Code == "" {
+	if (r.Code == "") && (r.GrantType != "client_credentials") {
 		return nil, fmt.Errorf("missing code")
 	}
 
@@ -64,8 +67,14 @@ func (c *Client) TokenWithContext(ctx context.Context, r *TokenRequest) (*TokenR
 
 	data := url.Values{}
 
-	data.Set("grant_type", "authorization_code")
-	data.Set("code", r.Code)
+	if r.GrantType != "" {
+		data.Set("grant_type", r.GrantType)
+	} else {
+		data.Set("grant_type", "authorization_code")
+	}
+	if r.Code != "" {
+		data.Set("code", r.Code)
+	}
 	data.Set("client_id", r.ClientID)
 	data.Set("client_secret", r.ClientSecret)
 


### PR DESCRIPTION
## Description

IMS Authentication will switch from JWT to OAuth server-to-server authentication.
This change will add support for the new client_credentials call to /ims/token endpoint
Reference: https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/migration/

## Related Issue

N/A

## Motivation and Context

Support for new authentication mechanism to allow migration to new concept.

## How Has This Been Tested?

* Tested locally towards IMS STAGE using existing credentials
* Automated tests

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.