### PR TITLE
FIX: client credentials expiry is calculated incorrectly

### DIFF
--- a/ims/cluster_exchange_token.go
+++ b/ims/cluster_exchange_token.go
@@ -87,7 +87,7 @@ func (c *Client) ClusterExchangeWithContext(ctx context.Context, r *ClusterExcha
 	return &ClusterExchangeResponse{
 		Response:    *res,
 		AccessToken: body.AccessToken,
-		ExpiresIn:   time.Millisecond * time.Duration(body.ExpiresIn),
+		ExpiresIn:   time.Second * time.Duration(body.ExpiresIn),
 	}, nil
 }
 

--- a/ims/cluster_exchange_token_test.go
+++ b/ims/cluster_exchange_token_test.go
@@ -59,7 +59,7 @@ func TestClusterExchange(t *testing.T) {
 		}{
 			TokenType:   "bearer",
 			AccessToken: "new-token",
-			ExpiresIn:   3600000,
+			ExpiresIn:   3600,
 		}
 
 		if err := json.NewEncoder(w).Encode(&body); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expiry was handled in milliseconds though token/v3 endpoint is returning the value in seconds
i.e. we might have considered sessions as expired too early

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.