### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
           - "1.20"
           - "1.21"
+          - "1.22"
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@
 
 module github.com/adobe/ims-go
 
-go 1.18
+go 1.20
 
 require github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
-github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/ims/client.go
+++ b/ims/client.go
@@ -11,6 +11,7 @@
 package ims
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -87,8 +88,8 @@ func (c *Client) do(req *http.Request) (_ *Response, e error) {
 	}
 
 	defer func() {
-		if err := res.Body.Close(); err != nil && e == nil {
-			e = fmt.Errorf("close body: %v", err)
+		if err := res.Body.Close(); err != nil {
+			e = errors.Join(e, fmt.Errorf("close body: %v", err))
 		}
 	}()
 


### PR DESCRIPTION
Upgrade to Go 1.20 as the latest baseline for this project. Add Go 1.22 as one of the versions tested in CI.