### PR TITLE
fix: serialize Resources in JWT exchange request body

### DIFF
--- a/ims/exchange_jwt.go
+++ b/ims/exchange_jwt.go
@@ -131,6 +131,10 @@ func (c *Client) ExchangeJWTWithContext(ctx context.Context, r *ExchangeJWTReque
 	data.Set("client_secret", r.ClientSecret)
 	data.Set("jwt_token", signed)
 
+	for _, res := range r.Resources {
+		data.Add("resource", res)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/ims/exchange/v1/jwt", c.url), strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %v", err)

--- a/ims/exchange_jwt_test.go
+++ b/ims/exchange_jwt_test.go
@@ -172,3 +172,89 @@ func TestExchangeJWTInvalidMetaScope(t *testing.T) {
 		t.Fatalf("invalid error: %v", err)
 	}
 }
+
+func TestExchangeJWTWithResources(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		resources := r.PostForm["resource"]
+		if len(resources) != 2 {
+			t.Fatalf("expected 2 resource values, got %d", len(resources))
+		}
+		if resources[0] != "https://api-alpha.example.com" {
+			t.Fatalf("invalid first resource: %v", resources[0])
+		}
+		if resources[1] != "https://api-beta.example.com" {
+			t.Fatalf("invalid second resource: %v", resources[1])
+		}
+
+		body := struct {
+			AccessToken string `json:"access_token"`
+			ExpiresIn   int    `json:"expires_in"`
+		}{
+			AccessToken: "access-token",
+			ExpiresIn:   3600000,
+		}
+		if err := json.NewEncoder(w).Encode(&body); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{URL: s.URL})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if _, err := c.ExchangeJWT(&ims.ExchangeJWTRequest{
+		PrivateKey:   newPrivateKey(t),
+		Expiration:   time.Now().Add(24 * time.Hour),
+		Issuer:       "organization",
+		Subject:      "technical-user",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Resources:    []string{"https://api-alpha.example.com", "https://api-beta.example.com"},
+	}); err != nil {
+		t.Fatalf("exchange JWT: %v", err)
+	}
+}
+
+func TestExchangeJWTWithoutResourcesOmitsParam(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if _, ok := r.PostForm["resource"]; ok {
+			t.Fatalf("resource should not be present when not set")
+		}
+
+		body := struct {
+			AccessToken string `json:"access_token"`
+			ExpiresIn   int    `json:"expires_in"`
+		}{
+			AccessToken: "access-token",
+			ExpiresIn:   3600000,
+		}
+		if err := json.NewEncoder(w).Encode(&body); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer s.Close()
+
+	c, err := ims.NewClient(&ims.ClientConfig{URL: s.URL})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if _, err := c.ExchangeJWT(&ims.ExchangeJWTRequest{
+		PrivateKey:   newPrivateKey(t),
+		Expiration:   time.Now().Add(24 * time.Hour),
+		Issuer:       "organization",
+		Subject:      "technical-user",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+	}); err != nil {
+		t.Fatalf("exchange JWT: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

`ExchangeJWTRequest.Resources` (added in #61) is declared but never written to the form-encoded request body, so the `resource` parameter is silently dropped on `/ims/exchange/v1/jwt` regardless of what callers set.

Match the existing pattern from `token.go` / `cluster_exchange_token.go` and add the missing `resource` form parameter for each entry in `Resources`. Tests mirror `TestTokenWithResource` / `TestTokenWithoutResourceOmitsParam` from `token_test.go`.

## How Has This Been Tested?

`go test -race ./...` — all green, including two new tests:
- `TestExchangeJWTWithResources` — asserts both values land in the form body as separate `resource` entries.
- `TestExchangeJWTWithoutResourcesOmitsParam` — asserts the parameter is omitted when not set.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)